### PR TITLE
Fix build with CMS 0.50.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
+    "babel-preset-react": "^6.11.1",
     "babel-register": "^6.11.6",
     "browser-sync": "^2.13.0",
     "css-loader": "^0.23.1",


### PR DESCRIPTION
`babel-preset-react` was in the CMS deps before, so it worked, but it was removed from the CMS deps during cleanup, breaking our build.
Fixes #7.

cc/ @erquhart 