### PR TITLE
Fix: -var typo & number overlap in ordered lists

### DIFF
--- a/src/css/imports/_cms.css
+++ b/src/css/imports/_cms.css
@@ -75,8 +75,9 @@
 		counter-reset: i 0;
     & >li:before {
       font-weight: 800;
-      left: -var(--spacing-medium);
-      position: absolute;
+      left: var(--spacing-medium);
+      margin-right: 1.33rem;
+      position: relative;
       height: 100%;
       content: counter(i);
       counter-increment: i;


### PR DESCRIPTION
Added "margin-right" and position should be relative; otherwise numbers overlap the text items in numbered lists