### PR TITLE
Pages appear in reverse order, updated list.html

### DIFF
--- a/site/layouts/_default/list.html
+++ b/site/layouts/_default/list.html
@@ -4,7 +4,7 @@
 
 <div class="mw7 center">
   <ul class="flex-ns flex-wrap mhn1-ns pa3">
-      {{ range (.Paginator 4).Pages.ByPublishDate }}
+      {{ range (.Paginator 4).Pages }}
           <div class="w-50-ns ph1-ns flex">
             {{ .Render "li"}}
           </div>

--- a/site/layouts/_default/list.html
+++ b/site/layouts/_default/list.html
@@ -4,7 +4,7 @@
 
 <div class="mw7 center">
   <ul class="flex-ns flex-wrap mhn1-ns pa3">
-      {{ range (.Paginator 4).Pages }}
+      {{ range (.Paginator 4).Pages.ByPublishDate.Reverse }}
           <div class="w-50-ns ph1-ns flex">
             {{ .Render "li"}}
           </div>


### PR DESCRIPTION
Since /post/ has a title *Latest stories*, pages shouldn't be sorted with `.ByDate` because they appear as oldest on top. 