### PR TITLE
Revert "Update dependency file-loader to v3"

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint": "^5.0.0",
     "eslint-plugin-import": "^2.0.0",
     "exports-loader": "^0.7.0",
-    "file-loader": "^3.0.0",
+    "file-loader": "^2.0.0",
     "gotrue-js": "^0.9.1",
     "gulp": "^3.9.1",
     "gulp-babel": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2935,9 +2935,9 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
-file-loader@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-3.0.0.tgz#56c5ce34bd94ac7a2a5afd49161483777983786a"
+file-loader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-2.0.0.tgz#39749c82f020b9e85901dcff98e8004e6401cfde"
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^1.0.0"


### PR DESCRIPTION
Reverts netlify-templates/one-click-hugo-cms#99

Drops Webpack 3 support, but this starter is still on Webpack 3.