### PR TITLE
fix: add 'name' attributes to name and email fields on contact form

### DIFF
--- a/site/layouts/partials/contact-form.html
+++ b/site/layouts/partials/contact-form.html
@@ -4,28 +4,28 @@
 
   <form action="">
     <div class="flex-l mhn1-l">
-          <!-- Name -->
+      <!-- Name -->
       <div class="ph1-l w-50-l">
         <fieldset>
-          <input type="text" id="name" placeholder="Name" class="w-100 mb2">
+          <input type="text" id="name" name="name" placeholder="Name" class="w-100 mb2">
           <label for="name">Name</label>
         </fieldset>
       </div>
-          <!-- Email -->
+      <!-- Email -->
       <div class="ph1-l w-50-l">
         <fieldset>
-          <input type="email" id="email" placeholder="Email" class="w-100 mb2">
+          <input type="email" id="email" name="email" placeholder="Email" class="w-100 mb2">
           <label for="email">Email</label>
         </fieldset>
       </div>
     </div>
 
-        <!-- Message -->
+    <!-- Message -->
     <fieldset>
-      <textarea name="name" placeholder="Your message" rows="8" cols="80" id="message" class="w-100"></textarea>
+      <textarea id="message" name="message" placeholder="Your message" rows="8" cols="80" class="w-100"></textarea>
       <label for="message">Your message</label>
     </fieldset>
-        <!-- Button -->
+    <!-- Button -->
     <div class="tc">
       <button type="submit" class="btn w-100 w-auto-ns raise">Submit</button>
     </div>


### PR DESCRIPTION
Without the `name` attribute, they don't show up in the netlify forms dashboard or in the notifications.