### PR TITLE
Fixing CSS bugs and making the blockquotes more usable

### DIFF
--- a/site/layouts/partials/media-block-reverse.html
+++ b/site/layouts/partials/media-block-reverse.html
@@ -1,7 +1,7 @@
 <div class="flex-m mhn3-m mb4">
 
   <div class="ph3-m w-50-m order-last-m">
-    <img src="{{.imageUrl}}" alt="" class="db mb2">
+    <img src="{{.imageUrl}}" alt="" class="db mb2 w-100" style="object-fit: cover">
   </div>
 
   <div class="ph3-m w-50-m">

--- a/site/layouts/partials/media-block.html
+++ b/site/layouts/partials/media-block.html
@@ -1,7 +1,7 @@
 <div class="flex-m mhn3-m mb4">
 
   <div class="ph3-m w-50-m">
-    <img src="{{.imageUrl}}" alt="" class="db mb2">
+    <img src="{{.imageUrl}}" alt="" class="db mb2 w-100" style="object-fit: cover">
   </div>
 
   <div class="ph3-m w-50-m">

--- a/src/css/imports/_cms.css
+++ b/src/css/imports/_cms.css
@@ -71,15 +71,14 @@
 
 	& ol {
 		list-style: none;
-		margin-left: var(--spacing-medium);
+		margin-left: 1.33rem;
 		counter-reset: i 0;
     & >li:before {
       font-weight: 800;
-      left: var(--spacing-medium);
-      margin-right: 1.33rem;
-      position: relative;
+      left: -1.33rem;
+      position: absolute;
       height: 100%;
-      content: counter(i);
+      content: counter(i) ".";
       counter-increment: i;
       color: var(--primary);
     }

--- a/src/css/imports/_cms.css
+++ b/src/css/imports/_cms.css
@@ -89,10 +89,14 @@
     background-color: var(--grey-1);
     display: block;
     border-radius: var(--border-radius);
+		border-top-left-radius: 0rem;
+		border-bottom-left-radius: 0rem;
+		border-left-style: solid;
+    border-left-width: var(--spacing-small);
+		border-color: var(--primary);
     padding: var(--spacing-medium);
-    color: var(--primary);
-    font-weight: 700;
-    font-size: 1.25rem;;
+		padding-left: calc( var(--spacing-small) + var(--spacing-medium));
+    font-size: 1rem;
     margin-bottom: var(--spacing-medium);
     & p {
       margin: 0;

--- a/src/css/imports/_spacing.css
+++ b/src/css/imports/_spacing.css
@@ -228,9 +228,18 @@
   margin-right: var(--spacing-extra-extra-extra-large);
 }
 
-.mhn1 { margin-left: -var(--spacing-extra-small); margin-right: -var(--spacing-extra-small); }
-.mhn2 { margin-left: -var(--spacing-small); margin-right: -var(--spacing-small); }
-.mhn3 { margin-left: -var(--spacing-medium); margin-right: -var(--spacing-medium); }
+.mhn1 {
+  margin-left: calc(-1 * var(--spacing-extra-small));
+  margin-right: calc(-1 * var(--spacing-extra-small));
+}
+.mhn2 {
+  margin-left: calc(-1 * var(--spacing-small));
+  margin-right: calc(-1 * var(--spacing-small)); 
+}
+.mhn3 {
+  margin-left: calc(-1 * var(--spacing-medium));
+  margin-right: calc(-1 * var(--spacing-medium));
+}
 
 @media (--breakpoint-not-small) {
   .pa0-ns  {  padding: var(--spacing-none); }
@@ -454,9 +463,18 @@
     margin-right: var(--spacing-extra-extra-extra-large);
   }
 
-  .mhn1-ns { margin-left: -var(--spacing-extra-small); margin-right: -var(--spacing-extra-small); }
-  .mhn2-ns { margin-left: -var(--spacing-small); margin-right: -var(--spacing-small); }
-  .mhn3-ns { margin-left: -var(--spacing-medium); margin-right: -var(--spacing-medium); }
+  .mhn1-ns {
+    margin-left: calc(-1 * var(--spacing-extra-small));
+    margin-right: calc(-1 * var(--spacing-extra-small));
+  }
+  .mhn2-ns {
+    margin-left: calc(-1 * var(--spacing-small));
+    margin-right: calc(-1 * var(--spacing-small));
+  }
+  .mhn3-ns {
+    margin-left: calc(-1 * var(--spacing-medium));
+    margin-right: calc(-1 * var(--spacing-medium));
+  }
 
 }
 
@@ -683,9 +701,18 @@
     margin-right: var(--spacing-extra-extra-extra-large);
   }
 
-  .mhn1-m { margin-left: -var(--spacing-extra-small); margin-right: -var(--spacing-extra-small); }
-  .mhn2-m { margin-left: -var(--spacing-small); margin-right: -var(--spacing-small); }
-  .mhn3-m { margin-left: -var(--spacing-medium); margin-right: -var(--spacing-medium); }
+  .mhn1-m {
+    margin-left: calc(-1 * var(--spacing-extra-small));
+    margin-right: calc(-1 * var(--spacing-extra-small));
+  }
+  .mhn2-m {
+    margin-left: calc(-1 * var(--spacing-small));
+    margin-right: calc(-1 * var(--spacing-small));
+  }
+  .mhn3-m {
+    margin-left: calc(-1 * var(--spacing-medium));
+    margin-right: calc(-1 * var(--spacing-medium));
+  }
 
 }
 
@@ -912,7 +939,16 @@
     margin-right: var(--spacing-extra-extra-extra-large);
   }
 
-  .mhn1-l { margin-left: -var(--spacing-extra-small); margin-right: -var(--spacing-extra-small); }
-  .mhn2-l { margin-left: -var(--spacing-small); margin-right: -var(--spacing-small); }
-  .mhn3-l { margin-left: -var(--spacing-medium); margin-right: -var(--spacing-medium); }
+  .mhn1-l {
+    margin-left: calc(-1 * var(--spacing-extra-small));
+    margin-right: calc(-1 * var(--spacing-extra-small));
+  }
+  .mhn2-l {
+    margin-left: calc(-1 * var(--spacing-small));
+    margin-right: calc(-1 * var(--spacing-small));
+  }
+  .mhn3-l {
+    margin-left: calc(-1 * var(--spacing-medium));
+    margin-right: calc(-1 * var(--spacing-medium));
+  }
 }


### PR DESCRIPTION
This pull request primarily fixes some bugs with the ordered lists and the `mhn` negative margin classes. It additionally redesigns the blockquotes to become more readable (black text, smaller font size) and uses `object-fit: cover` for the `media-block` partials, so all images have the same size.