### PR TITLE
Remove double </body></html> tags + fix mis-matched h-tags for blog "Latest stories"

### DIFF
--- a/site/layouts/partials/blog.html
+++ b/site/layouts/partials/blog.html
@@ -1,7 +1,7 @@
 <div class="bg-off-white pv4">
 	<div class="ph3 mw7 center">
 
-		<h2 class="f2 b lh-title mb3">Latest stories</h1>
+		<h2 class="f2 b lh-title mb3">Latest stories</h2>
 
 		<div class="w-100 flex-ns mhn1-ns flex-wrap mb3">
 			{{ range first 4 (where .Data.Pages "Type" "post") }}

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -51,7 +51,3 @@
 {{ partial "svg" . }}
 
 <script src="/app.js"></script>
-
-</body>
-
-</html>


### PR DESCRIPTION
1. Validating code shows duplicate </body></html> tags on every page. (Noob here - removing the </body></html> tag instances from the partials footer file worked.)

2. Blog "Latest stories" has mis-matched h-tags.
