### PR TITLE
Fixing CleanWebpackPlugin path for webpack.json.

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -29,7 +29,7 @@ module.exports = merge(common, {
       cleanOnceBeforeBuildPatterns: [
         "dist/**/*.js",
         "dist/**/*.css",
-        "site/content/webpack.json"
+        "site/data/webpack.json"
       ]}),
 
     new MiniCssExtractPlugin({


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/victor-hugo/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

`AssetsPlugin` in `webpack.common.js` is writing to `site/data`, not `site/content`.
Fixing `CleanWebpackPlugin` path for `webpack.json` accordingly.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

`npm run start` and `npm run build` building site successfully.

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixing `CleanWebpackPlugin` path for `webpack.json`.

**- A picture of a cute animal (not mandatory but encouraged)**

![jaguar](https://source.unsplash.com/Bg1w0hlbWy8/300x300)