### PR TITLE
Fix for loading non-svg images in CMS

### DIFF
--- a/src/js/cms-preview-templates/components/jumbotron.js
+++ b/src/js/cms-preview-templates/components/jumbotron.js
@@ -1,6 +1,7 @@
 import React from "react";
 
-const Jumbotron = ({image, title, subtitle}) => <div>
+const Jumbotron = ({image, title, subtitle}) =>
+<div>
   <div className="pv5 pv6-l ph3 bg-center cover" style={{
     backgroundImage: image && `url(${image})`
   }}>

--- a/src/js/cms-preview-templates/components/jumbotron.js
+++ b/src/js/cms-preview-templates/components/jumbotron.js
@@ -1,25 +1,22 @@
 import React from "react";
 
-export default class Jumbotron extends React.Component {
-  render() {
-    const {image, title, subtitle} = this.props;
-    return <div>
-      <div className="pv5 pv6-l ph3 bg-center cover" style={{
-        backgroundImage: image && `url(${image})`
-      }}>
-        <div className="mw7 center ph3">
-          <div className="db mb3">
-            <div className="mw7 relative bg-fix-primary mb3">
-              <h1 className="f2 f1-l b di lh-title mb3 white mw6 bg-primary">
-                { title }
-              </h1>
-            </div>
-            <div className="mw7 relative bg-fix-primary">
-              {subtitle && <p className="b f4 di lh-title mb3 white mw6 bg-primary">{ subtitle }</p>}
-            </div>
-          </div>
+const Jumbotron = ({image, title, subtitle}) => <div>
+  <div className="pv5 pv6-l ph3 bg-center cover" style={{
+    backgroundImage: image && `url(${image})`
+  }}>
+    <div className="mw7 center ph3">
+      <div className="db mb3">
+        <div className="mw7 relative bg-fix-primary mb3">
+          <h1 className="f2 f1-l b di lh-title mb3 white mw6 bg-primary">
+            { title }
+          </h1>
+        </div>
+        <div className="mw7 relative bg-fix-primary">
+          {subtitle && <p className="b f4 di lh-title mb3 white mw6 bg-primary">{ subtitle }</p>}
         </div>
       </div>
-    </div>;
-  }
-}
+    </div>
+  </div>
+</div>;
+
+export default Jumbotron;

--- a/src/js/cms-preview-templates/contact.js
+++ b/src/js/cms-preview-templates/contact.js
@@ -12,7 +12,7 @@ const ContactEntries = ({data}) => data && data.length > 0
   </div>
   : "";
 
-const ContactPreview = ({ entry, getAsset, widgetFor }) => {
+const ContactPreview = ({entry, widgetFor}) => {
   const entryContactEntries = entry.getIn(["data", "contact_entries"]);
   const contactEntries = entryContactEntries ? entryContactEntries.toJS() : [];
   return <div className="ph3 bg-off-white">

--- a/src/js/cms-preview-templates/contact.js
+++ b/src/js/cms-preview-templates/contact.js
@@ -7,22 +7,21 @@ const ContactEntry = ({heading, text}) =>
   </div>;
 
 const ContactEntries = ({data}) => data && data.length > 0
-    ? <div className="flex-ns mb3">
-      {data.map(({heading, text}) => <ContactEntry heading={heading} text={text} />)}
-    </div>
-    : "";
+  ? <div className="flex-ns mb3">
+    {data.map(({heading, text}) => <ContactEntry heading={heading} text={text} />)}
+  </div>
+  : "";
 
-export default class ContactPreview extends React.Component {
-  render() {
-    const {entry, getAsset, widgetFor} = this.props;
-    const entryContactEntries = entry.getIn(["data", "contact_entries"]);
-    const contactEntries = entryContactEntries ? entryContactEntries.toJS() : [];
-    return <div className="ph3 bg-off-white">
-      <img src={getAsset(entry.getIn(["data", "logo"]))} alt="" className="db w4 center pv4" />
-      <div className="center mw6 pv3">
-        { widgetFor("body") }
-        <ContactEntries data={contactEntries} />
-      </div>
-    </div>;
-  }
-}
+const ContactPreview = ({ entry, getAsset, widgetFor }) => {
+  const entryContactEntries = entry.getIn(["data", "contact_entries"]);
+  const contactEntries = entryContactEntries ? entryContactEntries.toJS() : [];
+  return <div className="ph3 bg-off-white">
+    <img src={entry.getIn(["data", "logo"])} alt="" className="db w4 center pv4" />
+    <div className="center mw6 pv3">
+      { widgetFor("body") }
+      <ContactEntries data={contactEntries} />
+    </div>
+  </div>;
+};
+
+export default ContactPreview;

--- a/src/js/cms-preview-templates/home.js
+++ b/src/js/cms-preview-templates/home.js
@@ -3,7 +3,8 @@ import format from "date-fns/format";
 
 import Jumbotron from "./components/jumbotron";
 
-const PostPreview = ({entry, getAsset}) => <div>
+const PostPreview = ({entry, getAsset}) =>
+<div>
   <Jumbotron image={entry.getIn(["data", "image"])} title={entry.getIn(["data", "title"])} subtitle={entry.getIn(["data", "subtitle"])}/>
 
   <div className="bg-grey-1 pv4">

--- a/src/js/cms-preview-templates/home.js
+++ b/src/js/cms-preview-templates/home.js
@@ -3,67 +3,55 @@ import format from "date-fns/format";
 
 import Jumbotron from "./components/jumbotron";
 
-export default class PostPreview extends React.Component {
-  render() {
-    const {entry, getAsset} = this.props;
-    let image = getAsset(entry.getIn(["data", "image"]));
+const PostPreview = ({ entry, getAsset }) => <div>
+  <Jumbotron image={entry.getIn(["data", "image"])} title={entry.getIn(["data", "title"])} subtitle={entry.getIn(["data", "subtitle"])}/>
 
-    // Bit of a nasty hack to make relative paths work as expected as a background image here
-    if (image && !image.fileObj) {
-        image = window.parent.location.protocol + "//" + window.parent.location.host + image;
-    }
+  <div className="bg-grey-1 pv4">
+    <div className="flex-l mhn1-l ph3 center mw7">
+      <h2 className="f2 b lh-title mb2 w-40-l">{entry.getIn(["data", "blurb", "heading"])}</h2>
+      <p className="w-60-l mb0">{entry.getIn(["data", "blurb", "text"])}</p>
+    </div>
+  </div>
 
-    return <div>
-        <Jumbotron image={image} title={entry.getIn(["data", "title"])} subtitle={entry.getIn(["data", "subtitle"])}/>
+  <div className="bg-off-white pv4">
+    <div className="ph3 mw7 center">
+      <h2 className="f2 b lh-title mb2">{entry.getIn(["data", "intro", "heading"])}</h2>
+      <p className="mb4 mw6">{entry.getIn(["data", "intro", "text"])}</p>
 
-        <div className="bg-grey-1 pv4">
-          <div className="flex-l mhn1-l ph3 center mw7">
-            <h2 className="f2 b lh-title mb2 w-40-l">{entry.getIn(["data", "blurb", "heading"])}</h2>
-            <p className="w-60-l mb0">{entry.getIn(["data", "blurb", "text"])}</p>
-          </div>
+      <div className="flex-ns mhn2-ns mb3">
+        {(entry.getIn(["data", "products"]) || []).map((product, i) => <div className="ph2-ns w-50-ns" key={i}>
+          <img src={getAsset(product.get("image"))} alt="" className="center db mb3" style={{width: "240px"}}/>
+          <p>{product.get("text")}</p>
+        </div>)}
+      </div>
+
+      <div className="tc">
+        <a href="#" className="btn raise">See all products</a>
+      </div>
+    </div>
+  </div>
+
+  <div className="bg-grey-1 pv4">
+    <div className="ph3 mw7 center">
+
+      <div className="flex-l mhn2-l">
+        <div className="w-40-l ph2-l">
+          <h2 className="f2 b lh-title mb2">{entry.getIn(["data", "values", "heading"])}</h2>
+
+          <p>{entry.getIn(["data", "values", "text"])}</p>
         </div>
 
-        <div className="bg-off-white pv4">
-          <div className="ph3 mw7 center">
-            <h2 className="f2 b lh-title mb2">{entry.getIn(["data", "intro", "heading"])}</h2>
-            <p className="mb4 mw6">{entry.getIn(["data", "intro", "text"])}</p>
-
-            <div className="flex-ns mhn2-ns mb3">
-              {(entry.getIn(["data", "products"]) || []).map((product, i) => <div className="ph2-ns w-50-ns" key={i}>
-                <img src={getAsset(product.get("image"))} alt="" className="center db mb3" style={{width: "240px"}}/>
-                <p>{product.get("text")}</p>
-              </div>)}
-            </div>
-
-            <div className="tc">
-              <a href="#" className="btn raise">See all products</a>
-            </div>
-          </div>
+        <div className="w-60-l ph2-l">
+          <img src="/img/home-about-section.jpg" alt="" className="mb3"/>
         </div>
+      </div>
 
-        <div className="bg-grey-1 pv4">
-          <div className="ph3 mw7 center">
-
-            <div className="flex-l mhn2-l">
-              <div className="w-40-l ph2-l">
-                <h2 className="f2 b lh-title mb2">{entry.getIn(["data", "values", "heading"])}</h2>
-
-                <p>{entry.getIn(["data", "values", "text"])}</p>
-              </div>
-
-              <div className="w-60-l ph2-l">
-                <img src="/img/home-about-section.jpg" alt="" className="mb3"/>
-              </div>
-            </div>
-
-            <div className="tc">
-              <a href="{{.buttonLink}}" className="btn raise">Read more</a>
-            </div>
-
-          </div>
-        </div>
-
+      <div className="tc">
+        <a href="{{.buttonLink}}" className="btn raise">Read more</a>
+      </div>
 
     </div>
-  }
-}
+  </div>
+</div>;
+
+export default PostPreview;

--- a/src/js/cms-preview-templates/home.js
+++ b/src/js/cms-preview-templates/home.js
@@ -3,8 +3,7 @@ import format from "date-fns/format";
 
 import Jumbotron from "./components/jumbotron";
 
-const PostPreview = ({entry, getAsset}) =>
-<div>
+const HomePreview = ({entry, getAsset}) => <div>
   <Jumbotron image={entry.getIn(["data", "image"])} title={entry.getIn(["data", "title"])} subtitle={entry.getIn(["data", "subtitle"])}/>
 
   <div className="bg-grey-1 pv4">
@@ -55,4 +54,4 @@ const PostPreview = ({entry, getAsset}) =>
   </div>
 </div>;
 
-export default PostPreview;
+export default HomePreview;

--- a/src/js/cms-preview-templates/home.js
+++ b/src/js/cms-preview-templates/home.js
@@ -3,7 +3,7 @@ import format from "date-fns/format";
 
 import Jumbotron from "./components/jumbotron";
 
-const PostPreview = ({ entry, getAsset }) => <div>
+const PostPreview = ({entry, getAsset}) => <div>
   <Jumbotron image={entry.getIn(["data", "image"])} title={entry.getIn(["data", "title"])} subtitle={entry.getIn(["data", "subtitle"])}/>
 
   <div className="bg-grey-1 pv4">

--- a/src/js/cms-preview-templates/post.js
+++ b/src/js/cms-preview-templates/post.js
@@ -1,22 +1,21 @@
 import React from "react";
 import format from "date-fns/format";
 
-export default class PostPreview extends React.Component {
-  render() {
-    const {entry, widgetFor, getAsset} = this.props;
-    let image = getAsset(entry.getIn(["data", "image"]));
+const PostPreview = ({entry, widgetFor}) => {
+  const image = entry.getIn(["data", "image"]);
 
-    return <div className="mw6 center ph3 pv4">
-      <h1 className="f2 lh-title b mb3">{ entry.getIn(["data", "title"])}</h1>
-      <div className="flex justify-between grey-3">
-        <p>{ format(entry.getIn(["data", "date"]), "ddd, MMM D, YYYY") }</p>
-        <p>Read in x minutes</p>
-      </div>
-      <div className="cms mw6">
-        <p>{ entry.getIn(["data", "description"]) }</p>
-        { image && <img src={ image } alt={ entry.getIn(["data", "title"])} /> }
-        { widgetFor("body") }
-      </div>
-    </div>;
-  }
-}
+  return <div className="mw6 center ph3 pv4">
+    <h1 className="f2 lh-title b mb3">{ entry.getIn(["data", "title"])}</h1>
+    <div className="flex justify-between grey-3">
+      <p>{ format(entry.getIn(["data", "date"]), "ddd, MMM D, YYYY") }</p>
+      <p>Read in x minutes</p>
+    </div>
+    <div className="cms mw6">
+      <p>{ entry.getIn(["data", "description"]) }</p>
+      { image && <img src={ image } alt={ entry.getIn(["data", "title"])} /> }
+      { widgetFor("body") }
+    </div>
+  </div>;
+};
+
+export default PostPreview;

--- a/src/js/cms-preview-templates/products.js
+++ b/src/js/cms-preview-templates/products.js
@@ -3,98 +3,88 @@ import format from "date-fns/format";
 
 import Jumbotron from "./components/jumbotron";
 
-export default class PostPreview extends React.Component {
-  render() {
-    const {entry, getAsset} = this.props;
-    let image = getAsset(entry.getIn(["data", "image"]));
+const ProductsPreview = ({ entry }) => <div>
+  <Jumbotron image={entry.getIn(["data", "image"])} title={entry.getIn(["data", "title"])} />
 
-    // Bit of a nasty hack to make relative paths work as expected as a background image here
-    if (image && !image.fileObj) {
-      image = window.parent.location.protocol + "//" + window.parent.location.host + image;
-    }
+  <div className="bg-off-white pv4">
+    <div className="ph3 mw7 center">
+      <h2 className="f2 b lh-title mb2">{entry.getIn(["data", "intro", "heading"])}</h2>
+      <p className="mb4 mw6">{entry.getIn(["data", "intro", "description"])}</p>
 
-    return <div>
-      <Jumbotron image={image} title={entry.getIn(["data", "title"])} />
-
-      <div className="bg-off-white pv4">
-        <div className="ph3 mw7 center">
-          <h2 className="f2 b lh-title mb2">{entry.getIn(["data", "intro", "heading"])}</h2>
-          <p className="mb4 mw6">{entry.getIn(["data", "intro", "description"])}</p>
-
-          <div className="flex-ns flex-wrap mhn2-ns mb3">
-            {(entry.getIn(["data", "intro", "blurbs"]) || []).map((blurb, index) => <div className="ph2-ns w-50-ns mb4" key={index}>
-              <img src={blurb.get("image") && getAsset(blurb.get("image"))} alt="" className="center db mb3" style={{width: "240px"}}/>
-              <p>{blurb.get("text")}</p>
-            </div>)}
-          </div>
-        </div>
-      </div>
-
-      <div className="mw7 center">
-        <div className="mw6 ph3 mb3">
-          <h3 className="f3 b lh-title mb2">{entry.getIn(["data", "main", "heading"])}</h3>
-          <p>{entry.getIn(["data", "main", "description"])}</p>
-        </div>
-      </div>
-
-      <div className="mw7 center ph3 pv4">
-
-        <div className="flex flex-wrap mhn1">
-          <div className="w-100 w-50-ns ph1-ns">
-            <img src={getAsset(entry.getIn(["data", "main", "image1", "image"]))}/>
-          </div>
-
-          <div className="w-100 w-50-ns ph1-ns">
-            <img src={getAsset(entry.getIn(["data", "main", "image2", "image"]))}/>
-          </div>
-
-          <div className="w-100 ph1-ns">
-            <img src={getAsset(entry.getIn(["data", "main", "image3", "image"]))}/>
-          </div>
-        </div>
-      </div>
-
-      <div className="pb4">
-        {(entry.getIn(['data', 'testimonials']) || []).map((testimonial, index) => <div className="center mb3 ph3" key={index}>
-        	<blockquote className="bg-grey-1 primary pa3 mb3 br1 b mw6 center">
-        		<p className="f4 mb0">“{testimonial.get('quote')}”</p>
-        		<cite className="tr db grey-3">{testimonial.get('author')}</cite>
-        	</blockquote>
+      <div className="flex-ns flex-wrap mhn2-ns mb3">
+        {(entry.getIn(["data", "intro", "blurbs"]) || []).map((blurb, index) => <div className="ph2-ns w-50-ns mb4" key={index}>
+          <img src={blurb.get("image") && blurb.get("image")} alt="" className="center db mb3" style={{width: "240px"}}/>
+          <p>{blurb.get("text")}</p>
         </div>)}
       </div>
+    </div>
+  </div>
 
-      <img src={getAsset(entry.getIn(['data', 'full_image']))} alt="" className="db w-100"/>
+  <div className="mw7 center">
+    <div className="mw6 ph3 mb3">
+      <h3 className="f3 b lh-title mb2">{entry.getIn(["data", "main", "heading"])}</h3>
+      <p>{entry.getIn(["data", "main", "description"])}</p>
+    </div>
+  </div>
 
-      <div className="bg-off-white pv4 ph3">
-      	<div className="mw7 center">
+  <div className="mw7 center ph3 pv4">
 
-      		<h2 className="f2 b lh-title mb3">{entry.getIn(['data', 'pricing', 'heading'])}</h2>
-      		<p className="mw6">{entry.getIn(['data', 'pricing', 'description'])}</p>
+    <div className="flex flex-wrap mhn1">
+      <div className="w-100 w-50-ns ph1-ns">
+        <img src={entry.getIn(["data", "main", "image1", "image"])}/>
+      </div>
 
-      		<div className="flex-ns mhn2-ns mw7">
-            {(entry.getIn(['data', 'pricing', 'plans']) || []).map((plan, index) => <div className="w-33-ns ph2" key={index}>
-              <div className="ph2">
+      <div className="w-100 w-50-ns ph1-ns">
+        <img src={entry.getIn(["data", "main", "image2", "image"])}/>
+      </div>
 
-              	<h3 className="b f5 grey-3 tc lh-title mb3">{plan.get('plan')}</h3>
+      <div className="w-100 ph1-ns">
+        <img src={entry.getIn(["data", "main", "image3", "image"])}/>
+      </div>
+    </div>
+  </div>
 
-              	<p className="primary f1 b tc lh-title center">
-              		<span className="f4">$</span>{plan.get('price')}
-              	</p>
+  <div className="pb4">
+    {(entry.getIn(['data', 'testimonials']) || []).map((testimonial, index) => <div className="center mb3 ph3" key={index}>
+      <blockquote className="bg-grey-1 primary pa3 mb3 br1 b mw6 center">
+        <p className="f4 mb0">“{testimonial.get('quote')}”</p>
+        <cite className="tr db grey-3">{testimonial.get('author')}</cite>
+      </blockquote>
+    </div>)}
+  </div>
+
+  <img src={entry.getIn(['data', 'full_image'])} alt="" className="db w-100"/>
+
+  <div className="bg-off-white pv4 ph3">
+    <div className="mw7 center">
+
+      <h2 className="f2 b lh-title mb3">{entry.getIn(['data', 'pricing', 'heading'])}</h2>
+      <p className="mw6">{entry.getIn(['data', 'pricing', 'description'])}</p>
+
+      <div className="flex-ns mhn2-ns mw7">
+        {(entry.getIn(['data', 'pricing', 'plans']) || []).map((plan, index) => <div className="w-33-ns ph2" key={index}>
+          <div className="ph2">
+
+            <h3 className="b f5 grey-3 tc lh-title mb3">{plan.get('plan')}</h3>
+
+            <p className="primary f1 b tc lh-title center">
+              <span className="f4">$</span>{plan.get('price')}
+            </p>
 
 -              	<p className="b">{plan.get('description')}</p>
 
-              	<ul>
-                  {(plan.get('items') || []).map((item, index) => <li key={index}>
-                    <p className={index + 1 !== plan.get('items').size ? "pb2 mb2 divider-grey" : null}>{item}</p>
-                  </li>)}
-              	</ul>
+            <ul>
+              {(plan.get('items') || []).map((item, index) => <li key={index}>
+                <p className={index + 1 !== plan.get('items').size ? "pb2 mb2 divider-grey" : null}>{item}</p>
+              </li>)}
+            </ul>
 
-              </div>
+          </div>
 
-            </div>)}
-      		</div>
-      	</div>
+        </div>)}
       </div>
-    </div>;
-  }
-}
+    </div>
+  </div>
+</div>;
+
+export default ProductsPreview;

--- a/src/js/cms-preview-templates/products.js
+++ b/src/js/cms-preview-templates/products.js
@@ -3,7 +3,7 @@ import format from "date-fns/format";
 
 import Jumbotron from "./components/jumbotron";
 
-const ProductsPreview = ({ entry }) => <div>
+const ProductsPreview = ({entry}) => <div>
   <Jumbotron image={entry.getIn(["data", "image"])} title={entry.getIn(["data", "title"])} />
 
   <div className="bg-off-white pv4">

--- a/src/js/cms-preview-templates/values.js
+++ b/src/js/cms-preview-templates/values.js
@@ -18,29 +18,21 @@ const MediaBlock = ({heading, text, imageUrl, reverse}) => {
   </div>;
 };
 
-export default class ValuesPreview extends React.Component {
-  render() {
-    const {entry, getAsset} = this.props;
-    
-    let image = getAsset(entry.getIn(["data", "image"]));
+const ValuesPreview = ({entry}) => {
 
-    // Bit of a nasty hack to make relative paths work as expected as a background image here
-    if (image && !image.fileObj) {
-      image = window.parent.location.protocol + "//" + window.parent.location.host + image;
-    }
-    
-    const entryValues = entry.getIn(["data", "values"]);
-    const values = entryValues ? entryValues.toJS() : [];
-    
-    return <div>
-      <Jumbotron image={image} title={entry.getIn(["data", "title"])} />
-      <div className="bg-off-white pv4">
-        <div className="mw7 center ph3 pt4">
-          {values.map(({text, heading, imageUrl}, i) =>
-            <MediaBlock key={i} text={text} heading={heading} imageUrl={imageUrl} reverse={i % 2 === 0} />
-          )}
-        </div>
+  const entryValues = entry.getIn(["data", "values"]);
+  const values = entryValues ? entryValues.toJS() : [];
+
+  return <div>
+    <Jumbotron image={entry.getIn(["data", "image"])} title={entry.getIn(["data", "title"])} />
+    <div className="bg-off-white pv4">
+      <div className="mw7 center ph3 pt4">
+        {values.map(({text, heading, imageUrl}, i) =>
+          <MediaBlock key={i} text={text} heading={heading} imageUrl={imageUrl} reverse={i % 2 === 0} />
+        )}
       </div>
-    </div>;
-  }
-}
+    </div>
+  </div>;
+};
+
+export default ValuesPreview;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/victor-hugo/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

In the CMS, I was not able to get non-svg images to load using getAsset for the longest time, but simply entry.getIn seems to do the trick.  The Jumbotron loads now, and I did not need to use the relative file path hack that was in the original file.  I think it has to do with getAsset returning a promise, but I am not 100% sure.  I hope that this fixes any image rendering issues that have popped up.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

Before:
![image](https://user-images.githubusercontent.com/30296062/74596336-c300fd00-5002-11ea-8c38-22b18e3207a8.png)

After:
![image](https://user-images.githubusercontent.com/30296062/74596343-dca24480-5002-11ea-8781-9808e3489ece.png)



**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Changed non-svg image fetch from getAsset to entry.getIn.