### PR TITLE
Fix: add cms back into build pipeline

### DIFF
--- a/src/cms.html
+++ b/src/cms.html
@@ -9,6 +9,6 @@
   <script src="https://identity-js.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>
 <body>
-  <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+    <script src="<%= htmlWebpackPlugin.publicPath %>/<%= htmlWebpackPlugin.files.js[1] %>"></script>
 </body>
 </html>

--- a/src/js/cms-preview-templates/post.js
+++ b/src/js/cms-preview-templates/post.js
@@ -9,7 +9,7 @@ export default class PostPreview extends React.Component {
     return <div className="mw6 center ph3 pv4">
       <h1 className="f2 lh-title b mb3">{ entry.getIn(["data", "title"])}</h1>
       <div className="flex justify-between grey-3">
-        <p>{ format(entry.getIn(["data", "date"]), "ddd, MMM D, YYYY") }</p>
+        <p>{ format(entry.getIn(["data", "date"]), "iii, MMM d, yyyy") }</p>
         <p>Read in x minutes</p>
       </div>
       <div className="cms mw6">

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -62,5 +62,10 @@ module.exports = {
         to: "fonts/",
       }]
     }),
+    new HtmlWebpackPlugin({
+      filename: "admin/index.html",
+      template: 'src/cms.html',
+      inject: true,
+    })
   ]
 };


### PR DESCRIPTION
# Summary

Worked with @maxcell to add the cms functionality back into the build and updated the post date format for day and year. 

# Addiitional Resources
Date format Docs: https://date-fns.org/v2.29.3/docs/format
Webpack plugin Docs: https://webpack.js.org/plugins/html-webpack-plugin/
Issue ref: fixes #678 